### PR TITLE
Validate profile existence more robustly

### DIFF
--- a/risk_matrix_cli.py
+++ b/risk_matrix_cli.py
@@ -180,7 +180,11 @@ def print_human(profile: RiskProfile) -> None:
 
 def main() -> None:
     args = parse_args()
-    profile = PROFILES[args.profile]
+       try:
+        profile = PROFILES[args.profile]
+    except KeyError:
+        raise SystemExit(f"Unknown profile: {args.profile!r}. Use --list-profiles to see options.")
+
 
     if args.json:
         payload: Dict[str, Any] = {


### PR DESCRIPTION
Though choices in argparse protects you, this also helps if main() is used programmatically with arbitrary strings.