### PR TITLE
Add explicit return type to print_human

### DIFF
--- a/risk_matrix_cli.py
+++ b/risk_matrix_cli.py
@@ -162,6 +162,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def print_human(profile: RiskProfile) -> None:
+    """Print a human-readable risk matrix for the given profile."""
     print("🔐 risk_matrix_cli")
     print(f"Profile : {profile.name} ({profile.key})")
     print("")


### PR DESCRIPTION
Make the side-effect-only nature of the function clearer.