### PR TITLE
Add simple error handling around main() for keyboard interrupt

### DIFF
--- a/risk_matrix_cli.py
+++ b/risk_matrix_cli.py
@@ -195,4 +195,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        raise SystemExit("\nAborted by user.")


### PR DESCRIPTION
Give a cleaner message if the user hits Ctrl+C.