### PR TITLE
Add a main() docstring and narrow its responsibilities

### DIFF
--- a/risk_matrix_cli.py
+++ b/risk_matrix_cli.py
@@ -179,6 +179,7 @@ def print_human(profile: RiskProfile) -> None:
 
 
 def main() -> None:
+    """Entry point for the risk_matrix_cli command-line interface."""
     args = parse_args()
     profile = PROFILES[args.profile]
 


### PR DESCRIPTION
Makes it clear that main() is the CLI wrapper, not business logic.